### PR TITLE
Don't extend `String` since it's really `StringType` at runtime

### DIFF
--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -6,14 +6,20 @@ isAdmin: {{this.model.isAdmin}}<br><br>
 <hr>
 
 {{#let (state (type "user") this.model) as |user|}}
+  <p>
+    <label> Has Errors: </label> {{user.name.hasErrors}}
+  </p>
   <form {{action "onsubmit" user on="submit"}}>
     Name: {{user.name.state}}<br>
     isAdmin: {{user.isAdmin.state}}<br><br>
 
-    <input type="text" onchange={{action user.name.set value="target.value"}} placeholder="name">
+    <input type="text" onchange={{action user.name.set value="target.value"}} placeholder="{{user.name.state}}">
     <button type="button" {{action user.isAdmin.toggle}}>Change role</button>
     <button type="submit">Submit</button>
+
   </form>
+
 {{/let}}
+
 
 {{outlet}}

--- a/app/types/user.js
+++ b/app/types/user.js
@@ -1,28 +1,28 @@
+import { Primitive } from 'microstates/dist/microstates.cjs';
 import { validate } from 'ember-validators';
 
 export default class User {
-  name = Field(String, [
+  name = Field([
     ['presence', { presence: true }]
   ]);
   isAdmin = Boolean;
 }
 
-export function Field(Type, validationArr) {
-  return class Field extends Type {
+export function Field(validationArr) {
+  return class Field extends Primitive {
+
     get validation() {
-      let value = valueOf(this);
+      let value = this.state;
       let results = validationArr.map((check) => {
         let [type, options] = check;
 
         return validate(type, value, options);
       });
 
-      debugger;
       return results;
-    }   
+    }
     get hasErrors() {
-      debugger;
-      return this.validation.length > 0;
+      return !!this.validation.some(result => result !== true);
     }
   }
 }


### PR DESCRIPTION
In order to make microstates convenient, `Number`, `String`, `Boolean` are actually standins for the microstate types `NumberType`, `StringType`, and `BooleanType` when specifying them as child properties:

```javascript
class MyThing {
  num = Number
  str = String
}
```

this gets expanded to:

```javascript
class MyThing {
  num = NumberType
  str = StringType
}
```

We can't do the same thing (or at least not very easily) with inheritance, so what was happening was that when the generated field `class Field extends String` constructor was being invoked, it was invoking the super String constructor which returned an instance of `String` "undefined", or "[object Object]" depending on the value that  got passed in. This in turn was messing up the child lookup because microstates thought there was a child for each character in the string.

This removes the inheritance (maybe containment is a better strategy) although it could be added back by exmplicitly `import { StringType } from 'microstates'` and descending from _that_ class.